### PR TITLE
Fix #108 Make external tag entries optional

### DIFF
--- a/src/main/resources/data/animus/tags/blocks/disallow_leach.json
+++ b/src/main/resources/data/animus/tags/blocks/disallow_leach.json
@@ -1,6 +1,9 @@
 {
   "values": [
-    "ic2:te",
+    {
+      "id": "ic2:te",
+      "required": false
+    },
     "minecraft:grass"
   ]
 }

--- a/src/main/resources/data/bloodmagic/tags/blocks/altar/runes.json
+++ b/src/main/resources/data/bloodmagic/tags/blocks/altar/runes.json
@@ -1,7 +1,13 @@
 {
   "replace": false,
   "values": [
-    "animus:arcane_rune",
-    "animus:rune_unleashed_nature"
+    {
+      "id": "animus:arcane_rune",
+      "required": false
+    },
+    {
+      "id": "animus:rune_unleashed_nature",
+      "required": false
+    }
   ]
 }

--- a/src/main/resources/data/curios/tags/items/spellbook.json
+++ b/src/main/resources/data/curios/tags/items/spellbook.json
@@ -1,6 +1,9 @@
 {
   "replace": false,
   "values": [
-    "animus:blood_infused_spellbook"
+    {
+      "id": "animus:blood_infused_spellbook",
+      "required": false
+    }
   ]
 }


### PR DESCRIPTION
Makes the tag entries optional and not required for the tag to work

Fixes the following tag errors:
<details>

[Load My Fucking Tags] Couldn't load certain entries with the tag curios:spellbook: animus:blood_infused_spellbook (from animus-3.0.15.jar)

[Load My Fucking Tags] Couldn't load certain entries with the tag bloodmagic:altar/runes: animus:arcane_rune (from animus 3.0.15.jar), animus:rune_unleashed_nature (from animus-3.0.15.jar)

[Load My Fucking Tags] Couldn't load certain entries with the tag animus:disallow_leach: ic2:te (from animus-3.0.15.jar) </details>